### PR TITLE
Corrected the response from /hafas/v1/station/

### DIFF
--- a/docs/swagger.json
+++ b/docs/swagger.json
@@ -5393,7 +5393,7 @@
 							"application/json": {
 								"schema": {
 									"items": {
-										"$ref": "#/components/schemas/Station"
+										"$ref": "#/components/schemas/HafasStation"
 									},
 									"type": "array"
 								}


### PR DESCRIPTION
The /hafas/v1/station/ responds with a HafasStation and not a Station.